### PR TITLE
Update ASF's GitHub repo link

### DIFF
--- a/communities.json
+++ b/communities.json
@@ -341,9 +341,9 @@
       "logo": "asf.png",
       "title": "ArchiSteamFarm",
       "quote": "C# application that allows you to farm steam cards using multiple steam accounts simultaneously.",
-      "quoteSourceUrl": "https://github.com/JustArchi/ArchiSteamFarm",
+      "quoteSourceUrl": "https://github.com/JustArchiNET/ArchiSteamFarm",
       "inviteCode": "hSQgt8j",
-      "githubUrl": "https://github.com/JustArchi/ArchiSteamFarm"
+      "githubUrl": "https://github.com/JustArchiNET/ArchiSteamFarm"
     },
     {
       "logo": "blink.png",


### PR DESCRIPTION
The repo was moved from private to organization, only URL has changed, you can confirm the move by going under **[old URL](https://github.com/JustArchi/ArchiSteamFarm)** and being redirected.

Thanks.