### PR TITLE
Update Gentoo Vanity URL

### DIFF
--- a/communities.json
+++ b/communities.json
@@ -434,7 +434,7 @@
       "title": "Gentoo Linux",
       "quote": "Gentoo Linux is free operating system based or Linux or FreeBSD that can be automatically optimized and customized for just about any application or need.",
       "quoteSourceUrl": "https://www.gentoo.org/",
-      "inviteCode": "QNMGcB6",
+      "inviteCode": "gentoo",
       "githubUrl": "https://github.com/gentoo"
     },
     {


### PR DESCRIPTION
Gentoo appears to have a vanity URL (/gentoo), but it's not used here.

The current invite listed is invalid/expired.